### PR TITLE
Allow set a dummy provider to return demo data

### DIFF
--- a/CuitService.Test/TaxInfoApiTest.cs
+++ b/CuitService.Test/TaxInfoApiTest.cs
@@ -86,6 +86,7 @@ namespace CuitService.Test
             using var appFactory = _factory.WithDisabledLifeTimeValidation()
                 .AddConfiguration(new Dictionary<string, string>()
                 {
+                    ["TaxInfoProvider:UseDummyData"] = "false",
                     ["TaxInfoProvider:Host"] = host,
                     ["TaxInfoProvider:UserName"] = expectedUserName,
                     ["TaxInfoProvider:Password"] = expectedPassword
@@ -105,6 +106,28 @@ namespace CuitService.Test
             httpCallAssertion.WithUrlPattern(expectedUrl);
             httpCallAssertion.WithHeader("UserName", expectedUserName);
             httpCallAssertion.WithHeader("Password", expectedPassword);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task GET_taxinfo_by_cuit_with_a_valid_CUIT_should_not_call_backend_when_UseDummyData_is_true()
+        {
+            // Arrange
+            using var appFactory = _factory.WithBypassAuthorization()
+                .AddConfiguration(new Dictionary<string, string>()
+                {
+                    ["TaxInfoProvider:UseDummyData"] = "true"
+                });
+            appFactory.Server.PreserveExecutionContext = true;
+            var client = appFactory.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, $"https://custom.domain.com/taxinfo/by-cuit/20-31111111-7");
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            _httpTest.ShouldNotHaveMadeACall();
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 

--- a/CuitService.Test/TaxInfoApi_ValidationTest.cs
+++ b/CuitService.Test/TaxInfoApi_ValidationTest.cs
@@ -2,6 +2,7 @@ using AutoFixture;
 using Flurl.Http.Testing;
 using Microsoft.AspNetCore.Mvc.Testing;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Text.Json;
@@ -183,7 +184,11 @@ namespace CuitService.Test
         {
             // Arrange
             _httpTest.RespondWithJson(new { });
-            var appFactory = _factory.WithBypassAuthorization();
+            var appFactory = _factory.WithBypassAuthorization()
+                .AddConfiguration(new Dictionary<string, string>()
+                {
+                    ["TaxInfoProvider:UseDummyData"] = "false"
+                });
             appFactory.Server.PreserveExecutionContext = true;
             var client = appFactory.CreateClient();
 

--- a/CuitService/Controllers/TaxInfoController.cs
+++ b/CuitService/Controllers/TaxInfoController.cs
@@ -14,30 +14,17 @@ namespace CuitService.Controllers
     public class TaxInfoController
     {
         private readonly ILogger<TaxInfoController> _logger;
-        private readonly TaxInfoProviderOptions _taxInfoProviderOptions;
+        private readonly ITaxInfoProviderService _taxInfoProviderService;
 
-        public TaxInfoController(ILogger<TaxInfoController> logger, IOptions<TaxInfoProviderOptions> taxInfoProviderOptions)
+        public TaxInfoController(ILogger<TaxInfoController> logger, ITaxInfoProviderService taxInfoProviderService)
         {
             _logger = logger;
-            _taxInfoProviderOptions = taxInfoProviderOptions.Value;
+            _taxInfoProviderService = taxInfoProviderService;
         }
 
         // TODO: rename cuitNumber parameter as cuit
         [HttpGet("/taxinfo/by-cuit/{cuit}")]
         public async Task<TaxInfo> GetTaxInfoByCuit([FromRoute] CuitNumber cuitNumber)
-        {
-            var url = new UriTemplate(_taxInfoProviderOptions.UriTemplate)
-                .AddParameter("host", _taxInfoProviderOptions.Host)
-                .AddParameter("cuit", cuitNumber.SimplifiedValue)
-                .Resolve();
-
-            var request = url
-                .WithHeader("UserName", _taxInfoProviderOptions.Username)
-                .WithHeader("Password", _taxInfoProviderOptions.Password);
-
-            var result = await request.GetJsonAsync<TaxInfo>();
-
-            return result;
-        }
+            => await _taxInfoProviderService.GetTaxInfoByCuit(cuitNumber);
     }
 }

--- a/CuitService/TaxInfoProvider/DummyTaxInfoProviderService.cs
+++ b/CuitService/TaxInfoProvider/DummyTaxInfoProviderService.cs
@@ -1,0 +1,40 @@
+using System.Threading.Tasks;
+
+namespace CuitService.TaxInfoProvider
+{
+    public class DummyTaxInfoProviderService : ITaxInfoProviderService
+    {
+        public DummyTaxInfoProviderService()
+        {
+        }
+
+        public Task<TaxInfo> GetTaxInfoByCuit(CuitNumber cuit)
+            => Task.FromResult(new TaxInfo()
+            {
+                ActividadPrincipal = "620100-SERVICIOS DE CONSULTORES EN INFORMÁTICA Y SUMINISTROS DE PROGRAMAS DE INFORMÁTICA",
+                Apellido = null,
+                CUIT = cuit.cuit,
+                CatIVA = "RI",
+                CatImpGanancias = "RI",
+                DomicilioCodigoPostal = "7600",
+                DomicilioDatoAdicional = null,
+                DomicilioDireccion = "CALLE FALSA 123 Piso:2",
+                DomicilioLocalidad = "MAR DEL PLATA SUR",
+                DomicilioPais = "AR",
+                DomicilioProvincia = "01",
+                DomicilioTipo = "FISCAL",
+                Error = false,
+                EstadoCUIT = "ACTIVO",
+                Message = null,
+                Monotributo = false,
+                MonotributoActividad = null,
+                MonotributoCategoria = null,
+                Nombre = null,
+                PadronData = null,
+                ParticipacionesAccionarias = true,
+                PersonaFisica = false,
+                RazonSocial = "RZS C.S. SA",
+                StatCode = 0
+            });
+    }
+}

--- a/CuitService/TaxInfoProvider/ITaxInfoProviderService.cs
+++ b/CuitService/TaxInfoProvider/ITaxInfoProviderService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace CuitService.TaxInfoProvider
+{
+    public interface ITaxInfoProviderService
+    {
+        Task<TaxInfo> GetTaxInfoByCuit(CuitNumber cuit);
+    }
+}

--- a/CuitService/TaxInfoProvider/TaxInfoProviderOptions.cs
+++ b/CuitService/TaxInfoProvider/TaxInfoProviderOptions.cs
@@ -2,6 +2,7 @@ namespace CuitService.TaxInfoProvider
 {
     public class TaxInfoProviderOptions
     {
+        public bool UseDummyData { get; set; }
         public string UriTemplate { get; set; } = string.Empty;
         public string Host { get; set; } = string.Empty;
         public string Username { get; set; } = string.Empty;

--- a/CuitService/TaxInfoProvider/TaxInfoProviderService.cs
+++ b/CuitService/TaxInfoProvider/TaxInfoProviderService.cs
@@ -1,0 +1,36 @@
+using Flurl.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Threading.Tasks;
+using Tavis.UriTemplates;
+
+
+namespace CuitService.TaxInfoProvider
+{
+    public class TaxInfoProviderService : ITaxInfoProviderService
+    {
+        private readonly ILogger<TaxInfoProviderService> _logger;
+        private readonly TaxInfoProviderOptions _taxInfoProviderOptions;
+
+        public TaxInfoProviderService(ILogger<TaxInfoProviderService> logger, IOptions<TaxInfoProviderOptions> taxInfoProviderOptions)
+        {
+            _logger = logger;
+            _taxInfoProviderOptions = taxInfoProviderOptions.Value;
+        }
+
+        public async Task<TaxInfo> GetTaxInfoByCuit(CuitNumber cuit)
+        {
+            var url = new UriTemplate(_taxInfoProviderOptions.UriTemplate)
+                .AddParameter("host", _taxInfoProviderOptions.Host)
+                .AddParameter("cuit", cuit.SimplifiedValue)
+                .Resolve();
+
+            var result = await url
+                .WithHeader("UserName", _taxInfoProviderOptions.Username)
+                .WithHeader("Password", _taxInfoProviderOptions.Password)
+                .GetJsonAsync<TaxInfo>();
+
+            return result;
+        }
+    }
+}

--- a/CuitService/TaxInfoProvider/TaxInfoProviderServiceCollectionExtensions.cs
+++ b/CuitService/TaxInfoProvider/TaxInfoProviderServiceCollectionExtensions.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             services.ConfigureOptions<ConfigureTaxInfoProviderOptions>();
 
+            services.AddTransient<ITaxInfoProviderService, TaxInfoProviderService>();
+
             return services;
         }
     }

--- a/CuitService/TaxInfoProvider/TaxInfoProviderServiceCollectionExtensions.cs
+++ b/CuitService/TaxInfoProvider/TaxInfoProviderServiceCollectionExtensions.cs
@@ -9,7 +9,16 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             services.ConfigureOptions<ConfigureTaxInfoProviderOptions>();
 
-            services.AddTransient<ITaxInfoProviderService, TaxInfoProviderService>();
+            services.AddSingleton<DummyTaxInfoProviderService>();
+            services.AddTransient<TaxInfoProviderService>();
+
+            services.AddTransient(serviceProvider =>
+            {
+                var taxInfoProviderOptions = serviceProvider.GetRequiredService<IOptions<TaxInfoProviderOptions>>();
+                return taxInfoProviderOptions.Value.UseDummyData
+                    ? (ITaxInfoProviderService)serviceProvider.GetRequiredService<DummyTaxInfoProviderService>()
+                    : serviceProvider.GetRequiredService<TaxInfoProviderService>();
+            });
 
             return services;
         }

--- a/CuitService/appsettings.Development.json
+++ b/CuitService/appsettings.Development.json
@@ -5,5 +5,8 @@
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "TaxInfoProvider": {
+    "UseDummyData": true
   }
 }


### PR DESCRIPTION
Hi @fgchaio, @swidzinskiMS, @VicThorX, @nreal and @FromDoppler/doppler-melmac 

This is to allow us to return dummy data without consuming the limited requests that we have in the real provider.

We have some overlap with #13, so, who merge after should work a little more.