### PR TITLE
CuitNumber value object

### DIFF
--- a/CuitService.Test/CuitNumberTest.cs
+++ b/CuitService.Test/CuitNumberTest.cs
@@ -1,0 +1,62 @@
+using AutoFixture;
+using Flurl.Http.Testing;
+using Microsoft.AspNetCore.Mvc.Testing;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CuitService.Test
+{
+    public class CuitNumberTest
+    {
+        [Theory]
+        [InlineData(null, "Value cannot be null. (Parameter 'value')", typeof(ArgumentNullException))]
+        [InlineData("", "The CUIT number cannot be empty. (Parameter 'value')", typeof(ArgumentException))]
+        [InlineData("    ", "The CUIT number cannot be empty. (Parameter 'value')", typeof(ArgumentException))]
+        [InlineData("---", "The CUIT number cannot be empty. (Parameter 'value')", typeof(ArgumentException))]
+        [InlineData(" - - - ", "The CUIT number cannot be empty. (Parameter 'value')", typeof(ArgumentException))]
+        [InlineData("20-31111111-8", "The CUIT's verification digit is wrong. (Parameter 'value')", typeof(ArgumentException))]
+        [InlineData("20-31111111-6", "The CUIT's verification digit is wrong. (Parameter 'value')", typeof(ArgumentException))]
+        [InlineData("20-31111111-1", "The CUIT's verification digit is wrong. (Parameter 'value')", typeof(ArgumentException))]
+        [InlineData("20-3111111-8", "The CUIT number must have 11 digits. (Parameter 'value')", typeof(ArgumentException))]
+        [InlineData("20-311111111-6", "The CUIT number must have 11 digits. (Parameter 'value')", typeof(ArgumentException))]
+        [InlineData("1234a5890", "The CUIT number cannot have other characters than numbers and dashes. (Parameter 'value')", typeof(ArgumentException))]
+        [InlineData("1234a", "The CUIT number cannot have other characters than numbers and dashes. (Parameter 'value')", typeof(ArgumentException))]
+        [InlineData("20 31111111 7", "The CUIT number cannot have other characters than numbers and dashes. (Parameter 'value')", typeof(ArgumentException))]
+        [InlineData("20x31111111x7", "The CUIT number cannot have other characters than numbers and dashes. (Parameter 'value')", typeof(ArgumentException))]
+        [InlineData("20,31111111,7", "The CUIT number cannot have other characters than numbers and dashes. (Parameter 'value')", typeof(ArgumentException))]
+        [InlineData("20_31111111_7", "The CUIT number cannot have other characters than numbers and dashes. (Parameter 'value')", typeof(ArgumentException))]
+        public void Ctor_should_validate_input(string value, string errorMessage, Type exceptionType)
+        {
+            // Assert
+            var exception = (ArgumentException)Assert.Throws(exceptionType, () =>
+            {
+                // Act
+                var cuitNumber = new CuitNumber(value!);
+            });
+
+            Assert.Equal(errorMessage, exception.Message);
+            Assert.Equal("value", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData("20311111117", "20311111117")]
+        [InlineData("33123456780", "33123456780")]
+        [InlineData("20-31111111-7", "20311111117")]
+        [InlineData("3-3-1-2-3-4-5-6-7-8-0", "33123456780")]
+        public void Ctor_should_parse_valid_input(string originalValue, string simplifiedValue)
+        {
+            // Act
+            var cuitNumber = new CuitNumber(originalValue);
+
+            // Assert
+            Assert.Equal(originalValue, cuitNumber.OriginalValue);
+            Assert.Equal(simplifiedValue, cuitNumber.SimplifiedValue);
+        }
+    }
+}

--- a/CuitService.Test/CuitNumberTest.cs
+++ b/CuitService.Test/CuitNumberTest.cs
@@ -45,11 +45,11 @@ namespace CuitService.Test
         }
 
         [Theory]
-        [InlineData("20311111117", "20311111117")]
-        [InlineData("33123456780", "33123456780")]
-        [InlineData("20-31111111-7", "20311111117")]
-        [InlineData("3-3-1-2-3-4-5-6-7-8-0", "33123456780")]
-        public void Ctor_should_parse_valid_input(string originalValue, string simplifiedValue)
+        [InlineData("20311111117", "20311111117", "20-31111111-7")]
+        [InlineData("33123456780", "33123456780", "33-12345678-0")]
+        [InlineData("20-31111111-7", "20311111117", "20-31111111-7")]
+        [InlineData("3-3-1-2-3-4-5-6-7-8-0", "33123456780", "33-12345678-0")]
+        public void Ctor_should_parse_valid_input(string originalValue, string simplifiedValue, string formattedValue)
         {
             // Act
             var cuitNumber = new CuitNumber(originalValue);
@@ -57,6 +57,8 @@ namespace CuitService.Test
             // Assert
             Assert.Equal(originalValue, cuitNumber.OriginalValue);
             Assert.Equal(simplifiedValue, cuitNumber.SimplifiedValue);
+            Assert.Equal(formattedValue, cuitNumber.FormattedValue);
+            Assert.Equal(formattedValue, cuitNumber.ToString());
         }
     }
 }

--- a/CuitService.Test/CuitNumberTest.cs
+++ b/CuitService.Test/CuitNumberTest.cs
@@ -189,5 +189,54 @@ namespace CuitService.Test
             httpCallAssertion.WithVerb(HttpMethod.Post);
             httpCallAssertion.WithRequestBody(expectedJson);
         }
+
+        [Theory]
+        [InlineData("20311111117", "20-31111111-7")]
+        [InlineData("33123456780", "33-12345678-0")]
+        [InlineData("20-31111111-7", "20-31111111-7")]
+        [InlineData("3-3-1-2-3-4-5-6-7-8-0", "33-12345678-0")]
+        public void Equivalent_CuitNumbers_should_be_evaluated_as_equal(string valueA, string valueB)
+        {
+            // Arrange
+            var cuitA = new CuitNumber(valueA);
+            var cuitB = new CuitNumber(valueB);
+
+            // Assert
+            Assert.Equal(cuitA, cuitB);
+            Assert.True(cuitA == cuitB);
+            Assert.False(cuitA != cuitB);
+            Assert.Equal(cuitA.GetHashCode(), cuitB.GetHashCode());
+        }
+
+        [Theory]
+        [InlineData("20311111117", "33-12345678-0")]
+        public void Non_Equivalent_CuitNumbers_should_be_evaluated_as_non_equal(string valueA, string valueB)
+        {
+            // Arrange
+            var cuitA = new CuitNumber(valueA);
+            var cuitB = new CuitNumber(valueB);
+
+            // Assert
+            Assert.NotEqual(cuitA, cuitB);
+            Assert.False(cuitA == cuitB);
+            Assert.True(cuitA != cuitB);
+            Assert.NotEqual(cuitA.GetHashCode(), cuitB.GetHashCode());
+        }
+
+        [Fact]
+        public void Compare_CuitNumbers_with_null_should_be_evaluated_as_non_equal()
+        {
+            // Arrange
+            var cuitA = new CuitNumber("20311111117");
+            var cuitB = (CuitNumber?)null;
+
+            // Assert
+            Assert.NotEqual(cuitA, cuitB);
+            Assert.NotEqual(cuitB, cuitA);
+            Assert.False(cuitA == cuitB!);
+            Assert.False(cuitB! == cuitA);
+            Assert.True(cuitA != cuitB!);
+            Assert.True(cuitB! != cuitA);
+        }
     }
 }

--- a/CuitService.Test/CuitNumberTest.cs
+++ b/CuitService.Test/CuitNumberTest.cs
@@ -1,11 +1,7 @@
-using AutoFixture;
 using Flurl.Http.Testing;
-using Microsoft.AspNetCore.Mvc.Testing;
 using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Xunit;
@@ -59,6 +55,44 @@ namespace CuitService.Test
             Assert.Equal(simplifiedValue, cuitNumber.SimplifiedValue);
             Assert.Equal(formattedValue, cuitNumber.FormattedValue);
             Assert.Equal(formattedValue, cuitNumber.ToString());
+        }
+
+        [Theory]
+        [InlineData("20311111117", "20311111117", "20-31111111-7")]
+        [InlineData("33123456780", "33123456780", "33-12345678-0")]
+        [InlineData("20-31111111-7", "20311111117", "20-31111111-7")]
+        [InlineData("3-3-1-2-3-4-5-6-7-8-0", "33123456780", "33-12345678-0")]
+        public void Parse_a_JSON_string_should_create_a_valid_CuitNumber(string originalValue, string simplifiedValue, string formattedValue)
+        {
+            // Arrange
+            var json = $"\"{originalValue}\"";
+
+            // Act
+            var cuitNumber = JsonSerializer.Deserialize<CuitNumber>(json);
+
+            // Assert
+            Assert.Equal(originalValue, cuitNumber.OriginalValue);
+            Assert.Equal(simplifiedValue, cuitNumber.SimplifiedValue);
+            Assert.Equal(formattedValue, cuitNumber.FormattedValue);
+            Assert.Equal(formattedValue, cuitNumber.ToString());
+        }
+
+        [Theory]
+        [InlineData("20311111117", "20-31111111-7")]
+        [InlineData("33123456780", "33-12345678-0")]
+        [InlineData("20-31111111-7", "20-31111111-7")]
+        [InlineData("3-3-1-2-3-4-5-6-7-8-0", "33-12345678-0")]
+        public void Stringify_CuitNumber_should_create_a_valid_JSON(string originalValue, string formattedValue)
+        {
+            // Arrange
+            var expectedJson = $"\"{formattedValue}\"";
+
+            // Act
+            var cuitNumber = new CuitNumber(originalValue);
+            var json = JsonSerializer.Serialize(cuitNumber);
+
+            // Assert
+            Assert.Equal(expectedJson, json);
         }
     }
 }

--- a/CuitService.Test/TaxInfoApi_ValidationTest.cs
+++ b/CuitService.Test/TaxInfoApi_ValidationTest.cs
@@ -87,9 +87,27 @@ namespace CuitService.Test
         }
 
         [Theory]
+        [InlineData("%20%20")]
+        [InlineData("%20 %20%20")]
+        public async Task GET_taxinfo_by_cuit_with_spaces_should_return_400_BadRequest(string cuit)
+        {
+            // Arrange
+            var client = _factory.WithBypassAuthorization().CreateClient();
+
+            // Act
+            var response = await client.GetAsync($"https://custom.domain.com/taxinfo/by-cuit/{cuit}");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+            _httpTest.ShouldNotHaveMadeACall();
+
+            await AssertCuitErrorMessage("The cuit field is required.", response);
+        }
+
+        [Theory]
         [InlineData("-")]
         [InlineData("-----")]
-        [InlineData("%20%20")]
         [InlineData("%20%20-")]
         [InlineData("-%20%20-")]
         public async Task GET_taxinfo_by_cuit_with_dashes_or_spaces_should_return_400_BadRequest(string cuit)

--- a/CuitService/Controllers/TaxInfoController.cs
+++ b/CuitService/Controllers/TaxInfoController.cs
@@ -22,9 +22,8 @@ namespace CuitService.Controllers
             _taxInfoProviderService = taxInfoProviderService;
         }
 
-        // TODO: rename cuitNumber parameter as cuit
         [HttpGet("/taxinfo/by-cuit/{cuit}")]
-        public async Task<TaxInfo> GetTaxInfoByCuit([FromRoute] CuitNumber cuitNumber)
-            => await _taxInfoProviderService.GetTaxInfoByCuit(cuitNumber);
+        public async Task<TaxInfo> GetTaxInfoByCuit([FromRoute][CuitNumberValidation] string cuit)
+            => await _taxInfoProviderService.GetTaxInfoByCuit(new CuitNumber() { OriginalValue = cuit });
     }
 }

--- a/CuitService/Controllers/TaxInfoController.cs
+++ b/CuitService/Controllers/TaxInfoController.cs
@@ -24,6 +24,6 @@ namespace CuitService.Controllers
 
         [HttpGet("/taxinfo/by-cuit/{cuit}")]
         public async Task<TaxInfo> GetTaxInfoByCuit([FromRoute][CuitNumberValidation] string cuit)
-            => await _taxInfoProviderService.GetTaxInfoByCuit(new CuitNumber() { OriginalValue = cuit });
+            => await _taxInfoProviderService.GetTaxInfoByCuit(new CuitNumber(cuit));
     }
 }

--- a/CuitService/Controllers/TaxInfoController.cs
+++ b/CuitService/Controllers/TaxInfoController.cs
@@ -23,7 +23,7 @@ namespace CuitService.Controllers
         }
 
         [HttpGet("/taxinfo/by-cuit/{cuit}")]
-        public async Task<TaxInfo> GetTaxInfoByCuit([FromRoute][CuitNumberValidation] string cuit)
-            => await _taxInfoProviderService.GetTaxInfoByCuit(new CuitNumber(cuit));
+        public async Task<TaxInfo> GetTaxInfoByCuit([FromRoute] CuitNumber cuit)
+            => await _taxInfoProviderService.GetTaxInfoByCuit(cuit);
     }
 }

--- a/CuitService/CuitNumber.cs
+++ b/CuitService/CuitNumber.cs
@@ -7,11 +7,9 @@ using System.ComponentModel;
 
 namespace CuitService
 {
-    // TODO: implement IComparable
-    // see https://andrewlock.net/using-strongly-typed-entity-ids-to-avoid-primitive-obsession-part-2/
     [JsonConverter(typeof(CuitNumberJsonConverter))]
     [TypeConverter(typeof(CuitNumberTypeConverter))]
-    public sealed class CuitNumber : IEquatable<CuitNumber>
+    public sealed class CuitNumber : IEquatable<CuitNumber>, IComparable<CuitNumber>, IComparable
     {
         private static readonly Regex CuitRegex = new Regex(@"(\d\d)-?(\d\d\d\d\d\d\d\d)-?(\d)", RegexOptions.Compiled);
         public string OriginalValue { get; }
@@ -101,5 +99,13 @@ namespace CuitService
 
         public override int GetHashCode()
             => SimplifiedValue.GetHashCode();
+
+        // TODO: add tests for comparisons
+        public int CompareTo(CuitNumber? other)
+            => SimplifiedValue.CompareTo(other?.SimplifiedValue);
+
+        public int CompareTo(object? obj)
+            => SimplifiedValue.CompareTo((obj as CuitNumber)?.SimplifiedValue);
+
     }
 }

--- a/CuitService/CuitNumber.cs
+++ b/CuitService/CuitNumber.cs
@@ -1,6 +1,4 @@
-using Microsoft.AspNetCore.Mvc;
 using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -9,8 +7,6 @@ namespace CuitService
 {
     // TODO: implement IEQualable and IComparable, add JsonConverter and TypeConverter attributes
     // see https://andrewlock.net/using-strongly-typed-entity-ids-to-avoid-primitive-obsession-part-2/
-    // TODO: Move this to a binding provider to avoid coupling with MVC
-    [ModelBinder(BinderType = typeof(CuitNumberModelBinder))]
     public sealed class CuitNumber
     {
         private static readonly Regex CuitRegex = new Regex(@"(\d\d)-?(\d\d\d\d\d\d\d\d)-?(\d)", RegexOptions.Compiled);

--- a/CuitService/CuitNumber.cs
+++ b/CuitService/CuitNumber.cs
@@ -2,11 +2,13 @@ using System;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Text.Json.Serialization;
 
 namespace CuitService
 {
-    // TODO: implement IEQualable and IComparable, add JsonConverter and TypeConverter attributes
+    // TODO: implement IEQualable and IComparable
     // see https://andrewlock.net/using-strongly-typed-entity-ids-to-avoid-primitive-obsession-part-2/
+    [JsonConverter(typeof(CuitNumberJsonConverter))]
     public sealed class CuitNumber
     {
         private static readonly Regex CuitRegex = new Regex(@"(\d\d)-?(\d\d\d\d\d\d\d\d)-?(\d)", RegexOptions.Compiled);

--- a/CuitService/CuitNumber.cs
+++ b/CuitService/CuitNumber.cs
@@ -3,12 +3,14 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Text.Json.Serialization;
+using System.ComponentModel;
 
 namespace CuitService
 {
     // TODO: implement IEQualable and IComparable
     // see https://andrewlock.net/using-strongly-typed-entity-ids-to-avoid-primitive-obsession-part-2/
     [JsonConverter(typeof(CuitNumberJsonConverter))]
+    [TypeConverter(typeof(CuitNumberTypeConverter))]
     public sealed class CuitNumber
     {
         private static readonly Regex CuitRegex = new Regex(@"(\d\d)-?(\d\d\d\d\d\d\d\d)-?(\d)", RegexOptions.Compiled);

--- a/CuitService/CuitNumber.cs
+++ b/CuitService/CuitNumber.cs
@@ -7,11 +7,11 @@ using System.ComponentModel;
 
 namespace CuitService
 {
-    // TODO: implement IEQualable and IComparable
+    // TODO: implement IComparable
     // see https://andrewlock.net/using-strongly-typed-entity-ids-to-avoid-primitive-obsession-part-2/
     [JsonConverter(typeof(CuitNumberJsonConverter))]
     [TypeConverter(typeof(CuitNumberTypeConverter))]
-    public sealed class CuitNumber
+    public sealed class CuitNumber : IEquatable<CuitNumber>
     {
         private static readonly Regex CuitRegex = new Regex(@"(\d\d)-?(\d\d\d\d\d\d\d\d)-?(\d)", RegexOptions.Compiled);
         public string OriginalValue { get; }
@@ -89,5 +89,17 @@ namespace CuitService
 
         public override string ToString()
             => FormattedValue;
+
+        public bool Equals(CuitNumber? other)
+            => SimplifiedValue.Equals(other?.SimplifiedValue);
+
+        public override bool Equals(object? obj)
+            => !(obj is null) && obj is CuitNumber other && Equals(other);
+
+        public static bool operator ==(CuitNumber a, CuitNumber b) => (a is null && b is null) || (!(a is null) && (a.CompareTo(b) == 0));
+        public static bool operator !=(CuitNumber a, CuitNumber b) => !(a == b);
+
+        public override int GetHashCode()
+            => SimplifiedValue.GetHashCode();
     }
 }

--- a/CuitService/CuitNumber.cs
+++ b/CuitService/CuitNumber.cs
@@ -13,9 +13,10 @@ namespace CuitService
     [ModelBinder(BinderType = typeof(CuitNumberModelBinder))]
     public sealed class CuitNumber
     {
-        // TODO: add a new field Formatted Value, and return that value in ToString
+        private static readonly Regex CuitRegex = new Regex(@"(\d\d)-?(\d\d\d\d\d\d\d\d)-?(\d)", RegexOptions.Compiled);
         public string OriginalValue { get; }
         public string SimplifiedValue { get; }
+        public string FormattedValue { get; }
 
         public CuitNumber(string value)
         {
@@ -33,6 +34,7 @@ namespace CuitService
 
             OriginalValue = value;
             SimplifiedValue = value.Replace("-", "");
+            FormattedValue = CuitRegex.Replace(SimplifiedValue, "$1-$2-$3");
         }
 
         public static ValidationResult ValidateNumber(string? value)
@@ -84,5 +86,8 @@ namespace CuitService
 
             return true;
         }
+
+        public override string ToString()
+            => FormattedValue;
     }
 }

--- a/CuitService/CuitNumber.cs
+++ b/CuitService/CuitNumber.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -8,6 +9,8 @@ namespace CuitService
 {
     // TODO: implement IEQualable and IComparable, add JsonConverter and TypeConverter attributes
     // see https://andrewlock.net/using-strongly-typed-entity-ids-to-avoid-primitive-obsession-part-2/
+    // TODO: Move this to a binding provider to avoid coupling with MVC
+    [ModelBinder(BinderType = typeof(CuitNumberModelBinder))]
     public sealed class CuitNumber
     {
         // TODO: add a new field Formatted Value, and return that value in ToString

--- a/CuitService/CuitNumber.cs
+++ b/CuitService/CuitNumber.cs
@@ -2,18 +2,35 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace CuitService
 {
-    // TODO: move validation inside constructor and ModelState updates inside a modelbinder,
-    // see https://docs.microsoft.com/en-us/aspnet/core/mvc/advanced/custom-model-binding?view=aspnetcore-3.1#custom-model-binder-sample
     // TODO: implement IEQualable and IComparable, add JsonConverter and TypeConverter attributes
     // see https://andrewlock.net/using-strongly-typed-entity-ids-to-avoid-primitive-obsession-part-2/
-    public class CuitNumber
+    public sealed class CuitNumber
     {
-        public string? OriginalValue { get; set; }
-        public string SimplifiedValue => OriginalValue?.Replace("-", "") ?? string.Empty;
         // TODO: add a new field Formatted Value, and return that value in ToString
+        public string OriginalValue { get; }
+        public string SimplifiedValue { get; }
+
+        public CuitNumber(string value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            var validationResult = ValidateNumber(value);
+
+            if (validationResult != ValidationResult.Success)
+            {
+                throw new ArgumentException(validationResult.ErrorMessage, nameof(value));
+            }
+
+            OriginalValue = value;
+            SimplifiedValue = value.Replace("-", "");
+        }
 
         public static ValidationResult ValidateNumber(string? value)
         {

--- a/CuitService/CuitNumberJsonConverter.cs
+++ b/CuitService/CuitNumberJsonConverter.cs
@@ -1,0 +1,18 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace CuitService
+{
+    public class CuitNumberJsonConverter : JsonConverter<CuitNumber>
+    {
+        public override CuitNumber Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
+        {
+            return new CuitNumber(reader.GetString());
+        }
+
+        public override void Write(Utf8JsonWriter writer, CuitNumber value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.FormattedValue);
+        }
+    }
+}

--- a/CuitService/CuitNumberModelBinder.cs
+++ b/CuitService/CuitNumberModelBinder.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using System.Threading.Tasks;
+
+namespace CuitService
+{
+    public class CuitNumberModelBinder : IModelBinder
+    {
+        public Task BindModelAsync(ModelBindingContext bindingContext)
+        {
+            var modelName = bindingContext.ModelName;
+
+            var valueProviderResult = bindingContext.ValueProvider.GetValue(modelName);
+
+            if (valueProviderResult == ValueProviderResult.None)
+            {
+                return Task.CompletedTask;
+            }
+
+            bindingContext.ModelState.SetModelValue(modelName, valueProviderResult);
+
+            var value = valueProviderResult.FirstValue;
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return Task.CompletedTask;
+            }
+
+            var errorMessage = CuitNumber.ValidateNumber(value);
+
+            if (errorMessage != null)
+            {
+                bindingContext.ModelState.TryAddModelError(
+                    modelName,
+                    errorMessage.ErrorMessage);
+                return Task.CompletedTask;
+            }
+
+            bindingContext.Result = ModelBindingResult.Success(new CuitNumber(value));
+            return Task.CompletedTask;
+        }
+    }
+
+}

--- a/CuitService/CuitNumberModelBinderProvider.cs
+++ b/CuitService/CuitNumberModelBinderProvider.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using System;
+
+namespace CuitService
+{
+    public class CuitNumberModelBinderProvider : IModelBinderProvider
+    {
+        public IModelBinder? GetBinder(ModelBinderProviderContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (context.Metadata.ModelType == typeof(CuitNumber))
+            {
+                return new CuitNumberModelBinder();
+            }
+
+            return null;
+        }
+    }
+}

--- a/CuitService/CuitNumberTypeConverter.cs
+++ b/CuitService/CuitNumberTypeConverter.cs
@@ -1,0 +1,32 @@
+using System;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+
+namespace CuitService
+{
+    public class CuitNumberTypeConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+        }
+
+        public override object? ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            var stringValue = value as string;
+            if (string.IsNullOrEmpty(stringValue))
+            {
+                return base.ConvertFrom(context, culture, value);
+            }
+
+            return new CuitNumber(stringValue);
+        }
+
+        public override bool IsValid(ITypeDescriptorContext context, object value)
+        {
+            var stringValue = value as string;
+            return CuitNumber.ValidateNumber(stringValue) == ValidationResult.Success;
+        }
+    }
+}

--- a/CuitService/CuitNumberValidationAttribute.cs
+++ b/CuitService/CuitNumberValidationAttribute.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace CuitService
+{
+    public class CuitNumberValidationAttribute : ValidationAttribute
+    {
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+            => CuitNumber.ValidateNumber(value as string);
+    }
+}

--- a/CuitService/Startup.cs
+++ b/CuitService/Startup.cs
@@ -19,7 +19,8 @@ namespace CuitService
         {
             services.AddDopplerSecurity();
             services.AddTaxInfoProvider();
-            services.AddControllers()
+            services.AddControllers(
+                options => options.ModelBinderProviders.Insert(0, new CuitNumberModelBinderProvider()))
                 .AddJsonOptions(options =>
                 {
                     options.JsonSerializerOptions.WriteIndented = true;

--- a/CuitService/TaxInfoProvider/DummyTaxInfoProviderService.cs
+++ b/CuitService/TaxInfoProvider/DummyTaxInfoProviderService.cs
@@ -13,7 +13,7 @@ namespace CuitService.TaxInfoProvider
             {
                 ActividadPrincipal = "620100-SERVICIOS DE CONSULTORES EN INFORMÁTICA Y SUMINISTROS DE PROGRAMAS DE INFORMÁTICA",
                 Apellido = null,
-                CUIT = cuit.cuit,
+                CUIT = cuit.OriginalValue,
                 CatIVA = "RI",
                 CatImpGanancias = "RI",
                 DomicilioCodigoPostal = "7600",

--- a/CuitService/TaxInfoProvider/DummyTaxInfoProviderService.cs
+++ b/CuitService/TaxInfoProvider/DummyTaxInfoProviderService.cs
@@ -13,7 +13,7 @@ namespace CuitService.TaxInfoProvider
             {
                 ActividadPrincipal = "620100-SERVICIOS DE CONSULTORES EN INFORMÁTICA Y SUMINISTROS DE PROGRAMAS DE INFORMÁTICA",
                 Apellido = null,
-                CUIT = cuit.OriginalValue,
+                CUIT = cuit.FormattedValue,
                 CatIVA = "RI",
                 CatImpGanancias = "RI",
                 DomicilioCodigoPostal = "7600",


### PR DESCRIPTION
Hi team, I was having fun (?) with _value ~~types~~ objects_, the idea was to learn what we need to have (TL;DR: it is a lot) a robust _value ~~type~~ object_ to avoid primitive obsession.

I have followed [Custom Model Binding documentation](https://docs.microsoft.com/en-us/aspnet/core/mvc/advanced/custom-model-binding?view=aspnetcore-3.1#custom-model-binder-sample) and [a post about how to avoid primitive obsession](https://andrewlock.net/using-strongly-typed-entity-ids-to-avoid-primitive-obsession-part-2/) and other sources that we need for this special case.

Could you review it? Does it make sense to have this kind of types?

**Update:** [Here you have a nice related article from Mark Seeman](https://blog.ploeh.dk/2015/01/19/from-primitive-obsession-to-domain-modelling/)