### PR TITLE
test: restore the test of JSON indentation

### DIFF
--- a/CuitService.Test/TaxInfoApiTest.cs
+++ b/CuitService.Test/TaxInfoApiTest.cs
@@ -145,8 +145,10 @@ namespace CuitService.Test
             var content = await response.Content.ReadAsStringAsync();
 
             // Assert
-            // Validate indentation
+            // Validate json format
             Assert.Matches(@"(?<=\"")([^\s,].*?)(?=\"")|null", content);
+            // Validate indentation
+            Assert.Matches(@"^{\r?\n\s+""(.+\r?\n)*}$", content);
             // Validate case sensitivity and making honor to model name case
             Assert.Matches(@"""EstadoCUIT"": ""ACTIVO""", content);
             Assert.Matches(@"""CUIT"": ""20-31111111-7""", content);


### PR DESCRIPTION
Hi team, 

I am restoring a test the was removed in #88 because of a not well-understanding of the meaning of the test.

The original idea was to verify if the JSON was indented or not:

<img width="653" alt="image" src="https://user-images.githubusercontent.com/1157864/114280486-dc87b400-9a0f-11eb-91ec-c307fe198c6b.png">

<img width="695" alt="image" src="https://user-images.githubusercontent.com/1157864/114280524-093bcb80-9a10-11eb-8656-886fff13bd51.png">

<img width="682" alt="image" src="https://user-images.githubusercontent.com/1157864/114280527-0ccf5280-9a10-11eb-9182-090a3369d90c.png">



